### PR TITLE
chore(dev-env): run Alembic on startup and add Make targets for migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: start start.backend start.frontend start.db stop logs migrate rebuild
+.PHONY: start start.backend start.frontend start.db stop logs migrate rebuild new-migration
 
 start:
 	docker compose up --build
@@ -26,3 +26,6 @@ migrate:
 rebuild:
 	docker compose build --no-cache
 
+new-migration:
+	@if [ -z "$(name)" ]; then echo "Error: provide name, e.g. make new-migration name='add users table'"; exit 1; fi; \
+		docker compose run --rm api alembic revision --autogenerate -m "$(name)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile.dev
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    command: sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
     working_dir: /app
     environment:
       - DATABASE_URL=postgresql+psycopg2://app:app@db:5432/app


### PR DESCRIPTION
### Changes
- Update api startup command in docker-compose.yml to run alembic upgrade head before launching Uvicorn
- Add new-migration target to Makefile (alongside existing migrate)

### How to use
**Generate migration from model changes:**
- `make new-migration name="migration name"`

**Apply all pending migrations:**
- `make migrate`