### PR TITLE
fix: /o-nas → /about in apps/app navbar and footer

### DIFF
--- a/apps/app/src/components/Footer/Footer.tsx
+++ b/apps/app/src/components/Footer/Footer.tsx
@@ -63,7 +63,7 @@ const Footer: React.FC = () => {
       <FooterInner>
         <Box as="div">
           <LinksRow $gap="lg" $align="center">
-            <FooterLink href={`${SITE_URL}/o-nas`}>O nas</FooterLink>
+            <FooterLink href={`${SITE_URL}/about`}>O nas</FooterLink>
             <Divider />
             <FooterLink href={`${SITE_URL}/pomoc`}>Pomoc</FooterLink>
             <Divider />

--- a/apps/app/src/components/Navbar/Navbar.tsx
+++ b/apps/app/src/components/Navbar/Navbar.tsx
@@ -308,7 +308,7 @@ const Navbar: React.FC = () => {
                 <ExternalStyledLink href={SITE_URL}>
                   Strona główna
                 </ExternalStyledLink>
-                <ExternalStyledLink href={`${SITE_URL}/o-nas`}>
+                <ExternalStyledLink href={`${SITE_URL}/about`}>
                   O nas
                 </ExternalStyledLink>
                 <ExternalStyledLink href={`${SITE_URL}/pomoc`}>
@@ -392,7 +392,7 @@ const Navbar: React.FC = () => {
                 <ExternalStyledLink href={SITE_URL}>
                   Strona główna
                 </ExternalStyledLink>
-                <ExternalStyledLink href={`${SITE_URL}/o-nas`}>
+                <ExternalStyledLink href={`${SITE_URL}/about`}>
                   O nas
                 </ExternalStyledLink>
                 <ExternalStyledLink href={`${SITE_URL}/pomoc`}>


### PR DESCRIPTION
The Next.js route is /about, not /o-nas.